### PR TITLE
Post on summer 2025 user groups

### DIFF
--- a/content/post/user-groups-july-august-2025.md
+++ b/content/post/user-groups-july-august-2025.md
@@ -1,0 +1,47 @@
+---
+layout: post
+title: "User Group Events in July and August 2025"
+author: "Michael S. Collier"
+date: 2025-07-23
+tags: [azure, community, user groups]
+---
+
+It’s shaping up to be a fun summer of sharing and learning, and I’d love for you to be part of it!
+
+I’ve got three user group presentations lined up through the end of August, and whether you’re into Azure development, curious about agentic workflows, or just enjoy free pizza and great conversation (who doesn’t?), there’s something here for you.
+
+Here’s where you can find me:
+
+## July 24: Getting Started with Azure Durable Task Scheduler
+
+:calendar: **Thursday, July 24th @ 5:30pm**
+
+:pushpin: [Central Ohio .NET Developer Group](https://www.meetup.com/central-ohio-net-developers-group-condg/events/308526642/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link&utm_version=v2)
+
+I'll be giving a lightning talk on getting started with the new Azure Durable Task Scheduler!
+
+In this lightning talk, we’ll explore the new Azure Durable Task Scheduler, a powerful tool for orchestrating durable workflows in .NET. You’ll learn how it solves common challenges with BYO storage providers, all while providing often requested features such as a local emulator, management dashboard, and other benefits of a managed service. We’ll walk through how to get it running both in Azure and locally, and I’ll demo how it integrates seamlessly with Azure Durable Functions to build resilient, scheduled workflows with minimal code.
+
+## August 13th: Agentic Workflows with Azure Functions and Friends
+
+:calendar: Wednesday, August 13th @ 5:30pm
+
+:pushpin: [Central Ohio .NET Developer Group](https://www.meetup.com/central-ohio-net-developers-group-condg/events/308526649/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link&utm_version=v2)
+
+Agent-based AI systems are reshaping how we build intelligent applications. How do you bring that power to production in a modern, cloud-native way?
+
+In this session, we’ll explore how to build scalable, serverless agentic workflows using the latest from the Microsoft ecosystem. You’ll see how .NET Aspire simplifies service composition and observability, how Azure Functions offers elastic execution for orchestration, and how Semantic Kernel and Azure OpenAI enable you to craft intelligent, multi-step AI agents with real-world utility.
+
+## August 28th: Agentic Workflows with Azure Functions and Friends
+
+:calendar: **Thursday, August 28th at 5:30pm**
+
+:pushpin: [Azure Columbus](https://www.meetup.com/central-ohio-azure/events/307350088/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link)
+
+If you missed the August 13th talk (or just want a second helping), I’ll be bringing the same energy to a different crowd.
+
+## See you soon
+
+I’d love to see some familiar faces in the crowd, and make some new friends too. Come for the tech, stay for the community.
+
+:cloud: If you’re planning to attend one (or more), drop me a note, I’d love to say hello!


### PR DESCRIPTION
This pull request adds a new blog post to the `content/post` directory, announcing user group events for July and August 2025. The post provides details about three upcoming presentations focused on Azure development and agentic workflows.

### New Blog Post Addition:

* `content/post/user-groups-july-august-2025.md`: Introduced a new blog post titled "User Group Events in July and August 2025," authored by Michael S. Collier. The post highlights three events:
  - A talk on the Azure Durable Task Scheduler on July 24th.
  - A session on agentic workflows with Azure Functions on August 13th.
  - A repeat of the agentic workflows session on August 28th for a different audience.