### PR TITLE
Rename blog post on removing magic strings from .NET Aspire projects

### DIFF
--- a/content/post/aspire-magic-strings.md
+++ b/content/post/aspire-magic-strings.md
@@ -1,7 +1,10 @@
 ---
 layout: post
-title: "Removing Secret Strings from Your .NET Aspire Project"
+title: "Removing Magic Strings from Your .NET Aspire Project"
 author: "Michael S. Collier"
+url: "aspire-magic-strings"
+aliases:
+    - "/aspire-secret-strings/"
 date: 2025-08-07T03:28:59Z
 tags: [dotnet, aspire]
 ---


### PR DESCRIPTION
Update the title and URL of the blog post to reflect the correct terminology regarding magic strings. Add an alias for the previous title for better accessibility.